### PR TITLE
Add help and fix freeze

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -28,6 +28,7 @@ namespace WankAPP
                         Console.WriteLine("wank slow - wanks slowly");
                         Console.WriteLine("help      - display help");
                         Console.WriteLine("exit      - exits app");
+                        line = Console.ReadLine();
                         break;
                     default:
                         goto case "help";

--- a/Program.cs
+++ b/Program.cs
@@ -24,10 +24,15 @@ namespace WankAPP
                         line = Console.ReadLine();
                         break;
                     case "help":
+                        Console.Clear();
+                        Console.WriteLine("Help: ");
                         Console.WriteLine("wank fast - wanks fast");
                         Console.WriteLine("wank slow - wanks slowly");
                         Console.WriteLine("help      - display help");
                         Console.WriteLine("exit      - exits app");
+                        Thread.Sleep(5000);
+                        Console.Clear();
+                        Console.WriteLine("Please Enter a Command");
                         line = Console.ReadLine();
                         break;
                     default:

--- a/Program.cs
+++ b/Program.cs
@@ -25,7 +25,7 @@ namespace WankAPP
                         break;
                     case "help":
                         Console.WriteLine("wank fast - wanks fast");
-                        Console.WriteLine("wank slow - wanks slow");
+                        Console.WriteLine("wank slow - wanks slowly");
                         Console.WriteLine("help      - display help");
                         Console.WriteLine("exit      - exits app");
                         break;

--- a/Program.cs
+++ b/Program.cs
@@ -23,6 +23,14 @@ namespace WankAPP
                         myWank.Do_Fap(Wank.WankSpeed.Slow, 50);
                         line = Console.ReadLine();
                         break;
+                    case "help":
+                        Console.WriteLine("wank fast - wanks fast");
+                        Console.WriteLine("wank slow - wanks slow");
+                        Console.WriteLine("help      - display help");
+                        Console.WriteLine("exit      - exits app");
+                        break;
+                    default:
+                        goto case "help";
                 }
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -15,16 +15,14 @@ namespace WankAPP
             {
                 switch (line)
                 {
-                    case ("wank fast"):
-                        line = "";
+                    case "wank fast":
                         myWank.Do_Fap(Wank.WankSpeed.Fast, 50);
                         line = Console.ReadLine();
                         break;
-                    case ("wank slow"):
-                        line = "";
+                    case "wank slow":
                         myWank.Do_Fap(Wank.WankSpeed.Slow, 50);
                         line = Console.ReadLine();
-                        break;  
+                        break;
                 }
             }
         }


### PR DESCRIPTION
So if you enter an unrecognized command, the application used to freeze.

Now it prints a fancy help, and you can also get help by issuing help.

Also I removed the brackets in the switch-cases since you dont need them and you didnt use them in the other switch-cases.